### PR TITLE
Pelco cameras cause exception with Types

### DIFF
--- a/lib/node-onvif.js
+++ b/lib/node-onvif.js
@@ -66,19 +66,29 @@ Onvif.prototype.startProbe = function(callback) {
 		this._udp.on('message', (buf, device_info) => {
 			this._OnvifSoap.parse(buf.toString()).then((result) => {
 				let type = '';
-				let probe_match = '';
 				let urn = '';
 				let xaddrs = [];
 				let scopes = [];
+				let types = '';
 				try {
-					type = result['Body']['ProbeMatches']['ProbeMatch']['Types'];
-					probe_match = result['Body']['ProbeMatches']['ProbeMatch'];
-					urn = probe_match['EndpointReference']['Address'];
-					xaddrs = probe_match['XAddrs'].split(/\s+/);
-					if(typeof(probe_match['Scopes']) === 'string') {
-						scopes = probe_match['Scopes'].split(/\s+/);
-					} else if(typeof(probe_match['Scopes']) === 'object' && typeof(probe_match['Scopes']['_']) === 'string') {
-						scopes = probe_match['Scopes']['_'].split(/\s+/);
+					let probe_matches = result['Body']['ProbeMatches']
+
+					// make sure the right data exists
+					if(probe_matches !== undefined) {
+						let probe_match = probe_matches['ProbeMatch'];
+						urn = probe_match['EndpointReference']['Address'];
+						xaddrs = probe_match['XAddrs'].split(/\s+/);
+						if(typeof(probe_match['Scopes']) === 'string') {
+							scopes = probe_match['Scopes'].split(/\s+/);
+						} else if(typeof(probe_match['Scopes']) === 'object' && typeof(probe_match['Scopes']['_']) === 'string') {
+							scopes = probe_match['Scopes']['_'].split(/\s+/);
+						}
+						// modified to support Pelco cameras
+						if(typeof(probe_match['Types']) === 'string') {
+							types = probe_match['Types'].split(/\s+/);
+						} else if(typeof(probe_match['Types']) === 'object' && typeof(probe_match['Types']['_']) === 'string') {
+							types = probe_match['Types']['_'].split(/\s+/)
+						}							
 					}
 				} catch(e) {
 					return;
@@ -103,7 +113,7 @@ Onvif.prototype.startProbe = function(callback) {
 							'name'    : name,
 							'hardware': hardware,
 							'location': location,
-							'types'   : probe_match['Types'].split(/\s+/),
+							'types'   : types,
 							'xaddrs'  : xaddrs,
 							'scopes'  : scopes
 						};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-onvif",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The node-onvif is a Node.js module which allows you to communicate with the network camera which supports the ONVIF specifications.",
   "main": "./lib/node-onvif.js",
   "files": [


### PR DESCRIPTION
This line was causing the error: 
`'types'   : probe_match['Types'].split(/\s+/), `
Fixed by adding similar code as was done for Scopes.

Also, added a bit of error handling with:
`if(probe_matches !== undefined) {`

Code is tested with Pelco and Hikvision cameras.

Updated version to 0.1.1