### PR TITLE
Fix error 'Failed to initialize the device: TypeError: profiles.forEa…

### DIFF
--- a/lib/modules/device.js
+++ b/lib/modules/device.js
@@ -469,6 +469,7 @@ OnvifDevice.prototype._mediaGetProfiles = function() {
 				reject(new Error('Failed to initialize the device: The targeted device does not any media profiles.'));
 				return;
 			}
+			profiles = [].concat(profiles) // in case profiles is not a list, then forEach below will report an error
 			profiles.forEach((p) => {
 				let profile = {
 					'token': p['$']['token'],


### PR DESCRIPTION
…ch is not a function'

root cause is that the profiles in response is not a list.