### PR TITLE
Add NAT support

### DIFF
--- a/lib/modules/device.js
+++ b/lib/modules/device.js
@@ -37,12 +37,14 @@ function OnvifDevice(params) {
 	this.xaddr = '';
 	this.user = '';
 	this.pass = '';
+  this.keepAddr = false;
 
 	if(('xaddr' in params) && typeof(params['xaddr']) === 'string') {
 		this.xaddr = params['xaddr'];
 		let ourl = mUrl.parse(this.xaddr);
 		this.address = ourl.hostname;
 	} else if(('address' in params) && typeof(params['address']) === 'string') {
+    this.keepAddr = true;
 		this.address = params['address'];
 		this.xaddr = 'http://' + this.address +':80/onvif/device_service';
 	} else {
@@ -400,7 +402,7 @@ OnvifDevice.prototype._getCapabilities = function() {
 			let events = c['Events'];
 			if(events && events['XAddr']) {
 				this.services.events = new mOnvifServiceEvents({
-					'xaddr'    : events['XAddr'],
+					'xaddr'    : this._getXaddr(events['XAddr']),
 					'time_diff': this.time_diff,
 					'user'     : this.user,
 					'pass'     : this.pass
@@ -420,7 +422,7 @@ OnvifDevice.prototype._getCapabilities = function() {
 			let media = c['Media'];
 			if(media && media['XAddr']) {
 				this.services.media = new mOnvifServiceMedia({
-					'xaddr': media['XAddr'],
+					'xaddr'    : this._getXaddr(media['XAddr']),
 					'time_diff': this.time_diff,
 					'user'     : this.user,
 					'pass'     : this.pass
@@ -429,7 +431,7 @@ OnvifDevice.prototype._getCapabilities = function() {
 			let ptz = c['PTZ'];
 			if(ptz && ptz['XAddr']) {
 				this.services.ptz = new mOnvifServicePtz({
-					'xaddr': ptz['XAddr'],
+					'xaddr'    : this._getXaddr(ptz['XAddr']),
 					'time_diff': this.time_diff,
 					'user'     : this.user,
 					'pass'     : this.pass
@@ -601,6 +603,7 @@ OnvifDevice.prototype._mediaGetStreamURI = function() {
 					this.services.media.getStreamUri(params, (error, result) => {
 						if(!error) {
 							let uri = result['data']['GetStreamUriResponse']['MediaUri']['Uri'];
+              uri = this._getUri(uri);
 							this.profile_list[profile_index]['stream'][protocol.toLowerCase()] = uri;
 						}
 						protocol_index ++;
@@ -646,5 +649,23 @@ OnvifDevice.prototype._mediaGetSnapshotUri = function() {
 	});
 	return promise;
 };
+
+OnvifDevice.prototype._getXaddr = function(directXaddr) {
+  if (!this.keepAddr) return directXaddr;
+  const path = mUrl.parse(directXaddr).path;
+  return 'http://' + this.address + path;
+}
+
+OnvifDevice.prototype._getUri = function(directUri) {
+  if (!this.keepAddr) return directUri;
+  const base = mUrl.parse('http://' + this.address);
+  const parts = mUrl.parse(directUri);
+  const newParts = {
+    host: base.host,
+    pathname: base.pathname + parts.pathname
+  }; 
+  const newUri = mUrl.format(newParts);
+  return newUri;
+}
 
 module.exports = OnvifDevice;

--- a/lib/modules/device.js
+++ b/lib/modules/device.js
@@ -635,8 +635,10 @@ OnvifDevice.prototype._mediaGetSnapshotUri = function() {
 				this.services.media.getSnapshotUri(params, (error, result) => {
 					if(!error) {
 						try {
-							profile['snapshot'] = result['data']['GetSnapshotUriResponse']['MediaUri']['Uri'];
-						} catch(e) {}
+              let snapshotUri = result['data']['GetSnapshotUriResponse']['MediaUri']['Uri'];
+              snapshotUri = this._getSnapshotUri(snapshotUri);
+							profile['snapshot'] = snapshotUri;
+						} catch(e) { console.log(e);}
 					}
 					profile_index ++;
 					getSnapshotUri();
@@ -661,6 +663,19 @@ OnvifDevice.prototype._getUri = function(directUri) {
   const base = mUrl.parse('http://' + this.address);
   const parts = mUrl.parse(directUri);
   const newParts = {
+    host: base.host,
+    pathname: base.pathname + parts.pathname
+  }; 
+  const newUri = mUrl.format(newParts);
+  return newUri;
+}
+
+OnvifDevice.prototype._getSnapshotUri = function(directUri) {
+  if (!this.keepAddr) return directUri;
+  const base = mUrl.parse('http://' + this.address);
+  const parts = mUrl.parse(directUri);
+  const newParts = {
+    protocol: parts.protocol,
     host: base.host,
     pathname: base.pathname + parts.pathname
   }; 

--- a/lib/modules/device.js
+++ b/lib/modules/device.js
@@ -46,7 +46,7 @@ function OnvifDevice(params) {
 	} else if(('address' in params) && typeof(params['address']) === 'string') {
     this.keepAddr = true;
 		this.address = params['address'];
-		this.xaddr = 'http://' + this.address +':80/onvif/device_service';
+		this.xaddr = 'http://' + this.address +'/onvif/device_service';
 	} else {
 		throw new Error('The parameter was invalid.');
 	}


### PR DESCRIPTION
This PR adds NAT/proxy support.

Currently after `_getCapabilities()` succeeds node-onvif will resolve to use direct ip address of the devices and ignore the xaddr/addess passed in by the user in  constructor `OnvifDevice`

This is undesired if the device is behind a NAT or is routed by an nginx server with multiple subpaths such as 10.10.1.2:8000 or 10.10.1.2/route-to-device/. node-onvif won't be able to connect.

Change in this PR allows user to pass in ip address or url pathname as the preferred connection string  so node-onvif will always use this value to connect to the device and ignore the device's internal ip address.

For example:
`OnvifDevice({ address: '10.10.2:300', user: 'user', 'pass': 'pass'})`
`OnvifDevice({ address: '10.10.1.2/route-to-device', user: 'user', 'pass': 'pass'})`

Tested with node 6 and 8