### PR TITLE
Reject promise on error in setNetworkProtocols

### DIFF
--- a/lib/modules/service-device.js
+++ b/lib/modules/service-device.js
@@ -656,27 +656,27 @@ OnvifServiceDevice.prototype.setNetworkProtocols = function(params, callback) {
 	let promise = new Promise((resolve, reject) => {
 		let err_msg = '';
 		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
-			callback(new Error('The value of "params" was invalid: ' + err_msg));
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
 			return;
 		}
 
 		if(err_msg = mOnvifSoap.isInvalidValue(params['NetworkProtocols'], 'array', true)) {
-			callback(new Error('The "NetworkProtocols" property was invalid: ' + err_msg));
+			reject(new Error('The "NetworkProtocols" property was invalid: ' + err_msg));
 			return;
 		}
 
 		for(let i=0; i<params['NetworkProtocols'].length; i++) {
 			let o = params['NetworkProtocols'][i];
 			if(err_msg = mOnvifSoap.isInvalidValue(o, 'object')) {
-				callback(new Error('The "NetworkProtocols" property was invalid: ' + err_msg));
+				reject(new Error('The "NetworkProtocols" property was invalid: ' + err_msg));
 				return;
 			}
 
 			if(err_msg = mOnvifSoap.isInvalidValue(o['Name'], 'string')) {
-				callback(new Error('The "Name" property was invalid: ' + err_msg));
+				reject(new Error('The "Name" property was invalid: ' + err_msg));
 				return;
 			} else if(!o['Name'].match(/^(HTTP|HTTPS|RTSP)$/)) {
-				callback(new Error('The "Name" property was invalid: It must be "HTTP", "HTTPS", or "RTSP".'));
+				reject(new Error('The "Name" property was invalid: It must be "HTTP", "HTTPS", or "RTSP".'));
 				return;
 			}
 
@@ -684,7 +684,7 @@ OnvifServiceDevice.prototype.setNetworkProtocols = function(params, callback) {
 
 			if('Enabled' in o) {
 				if(err_msg = mOnvifSoap.isInvalidValue(o['Enabled'], 'boolean')) {
-					callback(new Error('The "Enabled" property was invalid: ' + err_msg));
+					reject(new Error('The "Enabled" property was invalid: ' + err_msg));
 					return;
 				}
 				flag = true;
@@ -692,14 +692,14 @@ OnvifServiceDevice.prototype.setNetworkProtocols = function(params, callback) {
 
 			if('Port' in o) {
 				if(err_msg = mOnvifSoap.isInvalidValue(o['Port'], 'integer')) {
-					callback(new Error('The "Port" property was invalid: ' + err_msg));
+					reject(new Error('The "Port" property was invalid: ' + err_msg));
 					return;
 				}
 				flag = true;
 			}
 
 			if(flag === false) {
-				callbackError('Either "Enabled" or "Port" property is required.');
+				reject('Either "Enabled" or "Port" property is required.');
 				return;
 			}
 		}


### PR DESCRIPTION
If you follow the sample code for the `setNetworkProtocols` call, it shows that the `callback` parameter is optional.  However if the device returns an error, this function tries to call the callback anyway instead of rejecting the promise.

This patch fixes the problem by rejecting the promise in the same way that the other functions do.