### PR TITLE
Add imaging service support

### DIFF
--- a/lib/modules/device.js
+++ b/lib/modules/device.js
@@ -15,6 +15,7 @@ const mOnvifServiceDevice = require('./service-device.js');
 const mOnvifServiceMedia = require('./service-media.js');
 const mOnvifServicePtz = require('./service-ptz.js');
 const mOnvifServiceEvents = require('./service-events.js');
+const mOnvifServiceImaging = require('./service-imaging.js');
 const mOnvifHttpAuth = require('./http-auth.js');
 
 /* ------------------------------------------------------------------
@@ -412,14 +413,12 @@ OnvifDevice.prototype._getCapabilities = function () {
 			}
 			let imaging = c['Imaging'];
 			if (imaging && imaging['XAddr']) {
-				/*
 				this.services.imaging = new mOnvifServiceImaging({
-					'xaddr'    : imaging['XAddr'],
+					'xaddr': this._getXaddr(imaging['XAddr']),
 					'time_diff': this.time_diff,
 					'user'     : this.user,
 					'pass'     : this.pass
 				});
-				*/
 			}
 			let media = c['Media'];
 			if (media && media['XAddr']) {

--- a/lib/modules/service-imaging.js
+++ b/lib/modules/service-imaging.js
@@ -1,0 +1,451 @@
+/* ------------------------------------------------------------------
+* node-onvif - service-imaging.js
+*
+* Released under the MIT license
+* ---------------------------------------------------------------- */
+'use strict';
+const mUrl    = require('url');
+const mOnvifSoap = require('./soap.js');
+
+/* ------------------------------------------------------------------
+* Constructor: OnvifServiceImaging(params)
+* - params:
+*    - xaddr   : URL of the entry point for the media service
+*                (Required)
+*    - user  : User name (Optional)
+*    - pass  : Password (Optional)
+*    - time_diff: ms
+* ---------------------------------------------------------------- */
+function OnvifServiceImaging(params) {
+	this.xaddr = '';
+	this.user = '';
+	this.pass = '';
+
+	let err_msg = '';
+
+	if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+		throw new Error('The value of "params" was invalid: ' + err_msg);
+	}
+
+	if('xaddr' in params) {
+		if(err_msg = mOnvifSoap.isInvalidValue(params['xaddr'], 'string')) {
+			throw new Error('The "xaddr" property was invalid: ' + err_msg);
+		} else {
+			this.xaddr = params['xaddr'];
+		}
+	} else {
+		throw new Error('The "xaddr" property is required.');
+	}
+
+	if('user' in params) {
+		if(err_msg = mOnvifSoap.isInvalidValue(params['user'], 'string', true)) {
+			throw new Error('The "user" property was invalid: ' + err_msg);
+		} else {
+			this.user = params['user'] || '';
+		}
+	}
+
+	if('pass' in params) {
+		if(err_msg = mOnvifSoap.isInvalidValue(params['pass'], 'string', true)) {
+			throw new Error('The "pass" property was invalid: ' + err_msg);
+		} else {
+			this.pass = params['pass'] || '';
+		}
+	}
+
+	this.oxaddr = mUrl.parse(this.xaddr);
+	if(this.user) {
+		this.oxaddr.auth = this.user + ':' + this.pass;
+	}
+
+	this.time_diff = params['time_diff'];
+	this.name_space_attr_list = [
+		'xmlns:ter="http://www.onvif.org/ver10/error"',
+		'xmlns:xs="http://www.w3.org/2001/XMLSchema"',
+		'xmlns:tt="http://www.onvif.org/ver10/schema"',
+		'xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl"',
+		'xmlns:tns1="http://www.onvif.org/ver10/topics"'
+	];
+};
+
+OnvifServiceImaging.prototype._createRequestSoap = function(body) {
+	let soap = mOnvifSoap.createRequestSoap({
+		'body': body,
+		'xmlns': this.name_space_attr_list,
+		'diff': this.time_diff,
+		'user': this.user,
+		'pass': this.pass
+	});
+	return soap;
+};
+
+/* ------------------------------------------------------------------
+* Method: setAuth(user, pass)
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.setAuth = function(user, pass) {
+	this.user = user || '';
+	this.pass = pass || '';
+	if(this.user) {
+		this.oxaddr.auth = this.user + ':' + this.pass;
+	} else {
+		this.oxaddr.auth = '';
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getStatus(params[, callback])
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.getStatus = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:GetStatus>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body += '</timg:GetStatus>';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'GetStatus', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getServiceCapabilities(params[, callback])
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.getServiceCapabilities = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let soap_body = '';
+		soap_body += '<timg:GetServiceCapabilities />';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'GetServiceCapabilities', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getOptions(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required | a token for the video source
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1'
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.getOptions = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:GetOptions>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body += '</timg:GetOptions>';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'GetOptions', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getMoveOptions(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required | a token for the video source
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1'
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.getMoveOptions = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:GetMoveOptions>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body += '</timg:GetMoveOptions>';
+		let soap = this._createRequestSoap(soap_body);
+		mOnvifSoap.requestCommand(this.oxaddr, 'GetMoveOptions', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getImagingSettings(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required | a token for the video source
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1'
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.getImagingSettings = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:GetImagingSettings>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body += '</timg:GetImagingSettings>';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'GetImagingSettings', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: getOptions(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required | a token for the video source
+*   - Focus            | object  | optional | focus settings
+*     - AutoFocusMode  | String  | optional | enum { MANUAL, AUTO }
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1',
+*   'Focus': {
+*     'AutoFocusMode': 'MANUAL'
+*   }
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.setImagingSettings = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:SetImagingSettings>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body +=   '<timg:ImagingSettings>';
+		if (!mOnvifSoap.isInvalidValue(params['Focus'], 'object')) {
+			soap_body +=   '<tt:Focus>';
+			if(!mOnvifSoap.isInvalidValue(params['Focus']['AutoFocusMode'], 'string')) {
+				soap_body +=   '<tt:AutoFocusMode>' + params['Focus']['AutoFocusMode'] + '</tt:AutoFocusMode>';
+			}
+			soap_body +=   '</tt:Focus>';
+		}
+		soap_body +=   '</timg:ImagingSettings>';
+		soap_body += '</timg:SetImagingSettings>';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'SetImagingSettings', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: continuousMove(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required |
+*   - Speed            | Float   | required | focus
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1',
+*   'Speed': 1.0
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.continuousMove = function(params, callback) {
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['Speed'], 'float')) {
+			reject(new Error('The "Speed" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '';
+		soap_body += '<timg:Move>';
+		soap_body +=   '<timg:VideoSourceToken>' + params['VideoSourceToken'] + '</timg:VideoSourceToken>';
+		soap_body +=   '<timg:Focus>';
+		soap_body +=     '<tt:Continuous>';
+		soap_body +=       '<tt:Speed>' + params['Speed'] + '</tt:Speed>';
+		soap_body +=     '</tt:Continuous>';
+		soap_body +=   '</timg:Focus>';
+		soap_body += '</timg:Move>';
+		let soap = this._createRequestSoap(soap_body);
+		mOnvifSoap.requestCommand(this.oxaddr, 'Move', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+/* ------------------------------------------------------------------
+* Method: stop(params[, callback])
+* - params:
+*   - VideoSourceToken | String  | required | a token for the video source
+*
+* {
+*   'VideoSourceToken': 'VideoSourceToken1'
+* }
+* ---------------------------------------------------------------- */
+OnvifServiceImaging.prototype.stop = function(params, callback){
+	let promise = new Promise((resolve, reject) => {
+		let err_msg = '';
+		if(err_msg = mOnvifSoap.isInvalidValue(params, 'object')) {
+			reject(new Error('The value of "params" was invalid: ' + err_msg));
+			return;
+		}
+
+		if(err_msg = mOnvifSoap.isInvalidValue(params['VideoSourceToken'], 'string')) {
+			reject(new Error('The "VideoSourceToken" property was invalid: ' + err_msg));
+			return;
+		}
+
+		let soap_body = '<timg:Stop />';
+		let soap = this._createRequestSoap(soap_body);
+
+		mOnvifSoap.requestCommand(this.oxaddr, 'Stop', soap).then((result) => {
+			resolve(result);
+		}).catch((error) => {
+			reject(error);
+		});
+	});
+	if(callback) {
+		promise.then((result) => {
+			callback(null, result);
+		}).catch((error) => {
+			callback(error);
+		});
+	} else {
+		return promise;
+	}
+};
+
+module.exports = OnvifServiceImaging;

--- a/sample/manager/html/index.html
+++ b/sample/manager/html/index.html
@@ -71,8 +71,16 @@
 			</div>
 		</div>
 		<div class="ptz-zom-ctl-box btn-group btn-group-lg" role="group" aria-label="Zoom">
-			<button type="button" class="ptz-zom ptz-zom-ot btn btn-default"><span class="glyphicon glyphicon-zoom-out"></span></button>
-			<button type="button" class="ptz-zom ptz-zom-in btn btn-default"><span class="glyphicon glyphicon-zoom-in"></span></button>
+			<button type="button" class="ptz-zom ptz-zom-ot btn btn-default" title="Zoom Out"><span class="glyphicon glyphicon-zoom-out"></span></button>
+			<button type="button" class="ptz-zom ptz-zom-in btn btn-default" title="Zoom In"><span class="glyphicon glyphicon-zoom-in"></span></button>
+		</div>
+		<div class="focus-ctl-box btn-group btn-group-lg" role="group" aria-label="Focus">
+			<button type="button" class="focus-ot btn btn-default" title="Focus Near"><span class="glyphicon glyphicon-minus"></span></button>
+			<button type="button" class="focus-in btn btn-default" title="Focus Far"><span class="glyphicon glyphicon-plus"></span></button>
+		</div>
+		<div class="autofocus-ctl-box btn-group btn-group-lg" role="group" aria-label="Autofocus">
+			<button type="button" class="autofocus-on btn btn-default" title="Autofocus On"><span class="glyphicon glyphicon-eye-open"></span></button>
+			<button type="button" class="autofocus-off btn btn-default" title="Autofocus Off"><span class="glyphicon glyphicon-eye-close"></span></button>
 		</div>
 		<div class="disconnect-box">
 			<button type="button" class="form-control btn btn-default" name="disconnect">Disconnect</button>

--- a/sample/manager/html/onvif.js
+++ b/sample/manager/html/onvif.js
@@ -24,6 +24,10 @@ function OnvifManager() {
 		'ptz_pad' : $('#connected-device div.ptz-pad-box'),
 		'zom_in'  : $('#connected-device div.ptz-zom-ctl-box button.ptz-zom-in'),
 		'zom_out' : $('#connected-device div.ptz-zom-ctl-box button.ptz-zom-ot'),
+		'foc_in'  : $('#connected-device div.focus-ctl-box button.focus-in'),
+		'foc_out' : $('#connected-device div.focus-ctl-box button.focus-ot'),
+		'foc_on'  : $('#connected-device div.autofocus-ctl-box button.autofocus-on'),
+		'foc_off' : $('#connected-device div.autofocus-ctl-box button.autofocus-off'),
 	};
 	this.selected_address = '';
 	this.device_connected = false;
@@ -54,6 +58,21 @@ OnvifManager.prototype.init = function() {
 	this.el['zom_out'].on('mouseup', this.ptzStop.bind(this));
 	this.el['zom_out'].on('touchstart', this.ptzMove.bind(this));
 	this.el['zom_out'].on('touchend', this.ptzStop.bind(this));
+
+	this.el['foc_in'].on('mousedown', this.focusMove.bind(this));
+	this.el['foc_in'].on('mouseup', this.focusStop.bind(this));
+	this.el['foc_in'].on('touchstart', this.focusMove.bind(this));
+	this.el['foc_in'].on('touchend', this.focusStop.bind(this));
+
+	this.el['foc_out'].on('mousedown', this.focusMove.bind(this));
+	this.el['foc_out'].on('mouseup', this.focusStop.bind(this));
+	this.el['foc_out'].on('touchstart', this.focusMove.bind(this));
+	this.el['foc_out'].on('touchend', this.focusStop.bind(this));
+
+	this.el['foc_on'].on('click', this.enableAutofocus.bind(this));
+	this.el['foc_on'].on('touchend', this.enableAutofocus.bind(this));
+	this.el['foc_off'].on('click', this.disableAutofocus.bind(this));
+	this.el['foc_off'].on('touchend', this.disableAutofocus.bind(this));
 };
 
 OnvifManager.prototype.adjustSize = function() {
@@ -336,6 +355,68 @@ OnvifManager.prototype.ptzStop = function(event) {
 	this.sendRequest('ptzStop', {
 		'address': this.selected_address
 	});
+	this.ptz_moving = false;
+};
+
+OnvifManager.prototype.disableAutofocus = function(event) {
+	event.preventDefault();
+	event.stopPropagation();
+	if(this.device_connected === false) {
+		return;
+	}
+	this.sendRequest('setAutofocus', {
+		'address': this.selected_address,
+		'enabled': false
+	});
+};
+
+OnvifManager.prototype.enableAutofocus = function(event) {
+	event.preventDefault();
+	event.stopPropagation();
+	if(this.device_connected === false) {
+		return;
+	}
+	this.sendRequest('setAutofocus', {
+		'address': this.selected_address,
+		'enabled': true
+	});
+};
+
+OnvifManager.prototype.focusMove = function(event) {
+	if(this.device_connected === false) {
+		return;
+	}
+	var speed = 0.0;
+
+	if(event.type.match(/^(mousedown|touchstart)$/)) {
+		if(event.currentTarget.classList.contains('focus-ot')) {
+			speed = -1;
+		} else if(event.currentTarget.classList.contains('focus-in')) {
+			speed = 1;
+		} else {
+			return;
+		}
+	} else {
+		return;
+	}
+
+	this.sendRequest('focusMove', {
+		'address': this.selected_address,
+		'speed'  : speed
+	});
+	event.preventDefault();
+	event.stopPropagation();
+};
+
+OnvifManager.prototype.focusStop = function(event) {
+	if(!this.selected_address) {
+		return;
+	}
+
+	this.sendRequest('focusStop', {
+		'address': this.selected_address
+	})
+
 	this.ptz_moving = false;
 };
 

--- a/sample/manager/html/style.css
+++ b/sample/manager/html/style.css
@@ -130,3 +130,23 @@ h1 {
 #connected-device div.ptz-zom-ctl-box:hover {
 	opacity: 0.6;
 }
+
+#connected-device div.focus-ctl-box {
+	position: absolute;
+	bottom: 180px;
+	right: 1em;
+	opacity: 0.4;
+}
+#connected-device div.focus-ctl-box:hover {
+	opacity: 0.6;
+}
+
+#connected-device div.autofocus-ctl-box {
+	position: absolute;
+	bottom: 240px;
+	right: 1em;
+	opacity: 0.4;
+}
+#connected-device div.autofocus-ctl-box:hover {
+	opacity: 0.6;
+}


### PR DESCRIPTION
This PR adds imaging service (mainly to change focus) support.

Currently the sample application and library do not support changing autofocus mode or sending focus moves.

This is a desirable behavior for testing camera lenses in the workshop and in the field. This adds basic support for the imaging service in order to enable these types of tests, and includes an interface in the sample application to support enabling/disabling autofocus.

This has been tested with Dahua and Sony devices on Node 8.

Reviewed by @ohrite
